### PR TITLE
Update sample entropy

### DIFF
--- a/pyentrp/entropy.py
+++ b/pyentrp/entropy.py
@@ -101,13 +101,13 @@ def shannon_entropy(time_series):
     return ent
 
 
-def sample_entropy(timeseries, m, r = None):
-    """Calculates the sample entropy of degree m of a timeseries.
+def sample_entropy(time_series, m, tol = None):
+    """Calculates the sample entropy of degree m of a time_series.
     
     This method uses chebychev norm and searches iteratively. It is quite fast for random data, but can be slower is there is structure in the time series. 
     
     Args:
-        timeseries: numpy array of time series
+        time_series: numpy array of time series
         m: length of template vector
         r: tolerance (defaults to 0.1 * std(time_series)))
     Returns: 
@@ -120,21 +120,21 @@ def sample_entropy(timeseries, m, r = None):
             of biological signals
             """
         
-    if r == None:
-        r = 0.1*np.std(timeseries)
+    if tol is None:
+        tol = 0.1*np.std(time_series)
 
-    n = len(timeseries)
+    n = len(time_series)
     Ntemp = 0;
     Ntemp_plus = 0;
     for i in range(n-m-1):
-        template = timeseries[i:(i+m+1)];#We have 'm+1' elements in the template
-        remtimeseries = timeseries[i+1:]
+        template = time_series[i:(i+m+1)];#We have 'm+1' elements in the template
+        rem_time_series = time_series[i+1:]
         
-        """Search for matches in remtimeseries. First we look for match with template[0]. 
+        """Search for matches in remtime_series. First we look for match with template[0]. 
         We then select the neighbors of these that also match next elements """
         
         "Create a list with those indices in the time series that match the first element in template"
-        searchlist = np.nonzero(np.abs(remtimeseries - template[0]) < r)[0]
+        searchlist = np.nonzero(np.abs(rem_time_series - template[0]) < tol)[0]
 
         go = len(searchlist) > 0;
         
@@ -153,10 +153,10 @@ def sample_entropy(timeseries, m, r = None):
             nextindxlist = nextindxlist[nextindxlist < n - 1 - i]
            
             "This is the list of elements that we shopuld compare with the next entry in the template vector:"
-            nextcandidates = remtimeseries[nextindxlist]
+            nextcandidates = rem_time_series[nextindxlist]
             
-            "Hitlist is bool list and true where next timeseries elements match next template elements"
-            hitlist = np.abs(nextcandidates - template[length]) < r
+            "Hitlist is bool list and true where next time_series elements match next template elements"
+            hitlist = np.abs(nextcandidates - template[length]) < tol
             "reduce the search list to those elements that surviced this round"
             searchlist = nextindxlist[hitlist]
            

--- a/pyentrp/entropy.py
+++ b/pyentrp/entropy.py
@@ -14,7 +14,7 @@ def util_hash_term(perm):
     Returns:  
         int
     
-    Added by Jakob Dreyer, 2018, Dept Bioinformatics, H Lundbcek A/S, Denmark"""
+    Added by Jakob Dreyer, 2018, Dept Bioinformatics, H Lundbeck A/S, Denmark"""
     
     deg = len(perm)
     return sum([perm[k]*deg**k for k in range(deg)])

--- a/pyentrp/entropy.py
+++ b/pyentrp/entropy.py
@@ -120,7 +120,8 @@ def sample_entropy(timeseries, m, r = None):
             of biological signals
             """
         
-    
+    if r == None:
+        r = 0.1*np.std(timeseries)
 
     n = len(timeseries)
     Ntemp = 0;

--- a/pyentrp/entropy.py
+++ b/pyentrp/entropy.py
@@ -63,9 +63,8 @@ def util_granulate_time_series(time_series, scale):
     """
     n = len(time_series)
     b = int(np.fix(n / scale))
-    cts = [0] * b
-    for i in range(b):
-        cts[i] = np.mean(time_series[i * scale: (i + 1) * scale])
+    temp = np.reshape(time_series[0:b*scale], (b, scale))
+    cts = np.mean(temp, axis = 1)
     return cts
 
 


### PR DESCRIPTION
Hi Nikolay

Sorry for the delay. Here is a PR containing my work on the sample_entropy function (there is also a small change in util_granulate_time_series). There are quite a few changes. 

I tried to keep the old sample_entropy-implementation in the package as you suggested, but, for some reason, it only gave same output as the wikipedia implementation when tested on exactly the same integer time series as in your test-script and only with m = 4. I therefore removed it.  I suspect some problem in the distance measure, but I am not sure. 

The input and output from sample_entropy in this PR is fully equivalent to the 'wikipedia-implementation' using Chebychev norm, but much faster (see timings below). 

Note that the current version of SE calculates SE on the basis of number of matches with templates of length m and comparing with templates of length m+1. Thus m = 3 means we calculate the number of times where matching template of length 3 also matches with template of length 4. I think this is the correct definition and it is the one used in the 'wikipedia-script' .  The previous version compared number of 'm -1'  templates to length m.  In short this means that m = 3 is the same as m = 4 in the previous version. 

I pasted some testcode and timings and outputs below. 

Best regards
Jakob. 


**OUTPUT FROM TESTSCRIPT**


```
---------------------------   
Testing on random floats (N = 3000)
test series:  [0.25575617 0.58570927 0.86335804 0.59820787 0.61461345] ...
New:
SE: 1.661302233034878 
Time =  0.533 s

WIKI (cheby):
SE: 1.661302233034878 
Time =  31.719 s

Old version:
SE: [1.65801703 1.65440792 1.64963807 1.66050673] 
Time =  9.858 s
---------------------------   
Testing on random integers from test-script:
test series:  [1 4 5 1 7] ...
New:
SE: 1.791759469228055 

WIKI (cheby):
SE: 1.791759469228055 

Old version:
SE: [2.21187685 2.10787948 2.36712361 1.79175947] 

```

**TESTSCRIPT:**


```

import numpy as np



def sample_entropy_keep(time_series, sample_length, tolerance=None):
    """Calculate and return Sample Entropy of the given time series.
    Distance between two vectors defined as Euclidean distance and can
    be changed in future releases
    Args:
        time_series: Vector or string of the sample data
        sample_length: Number of sequential points of the time series
        tolerance: Tolerance (default = 0.1...0.2 * std(time_series))
    Returns:
        Vector containing Sample Entropy (float)
    References:
        [1] http://en.wikipedia.org/wiki/Sample_Entropy
        [2] http://physionet.incor.usp.br/physiotools/sampen/
        [3] Madalena Costa, Ary Goldberger, CK Peng. Multiscale entropy analysis
            of biological signals
    """
    if tolerance is None:
        tolerance = 0.1 * np.std(time_series)

    n = len(time_series)
    prev = np.zeros(n)
    curr = np.zeros(n)
    A = np.zeros((sample_length, 1))  # number of matches for m = [1,...,template_length - 1]
    B = np.zeros((sample_length, 1))  # number of matches for m = [1,...,template_length]

    for i in range(n - 1):
        nj = n - i - 1
        ts1 = time_series[i]
        for jj in range(nj):
            j = jj + i + 1
            if abs(time_series[j] - ts1) < tolerance:  # distance between two vectors
                curr[jj] = prev[jj] + 1
                temp_ts_length = min(sample_length, curr[jj])
                for m in range(int(temp_ts_length)):
                    A[m] += 1
                    if j < n - 1:
                        B[m] += 1
            else:
                curr[jj] = 0
        for j in range(nj):
            prev[j] = curr[j]

    N = n * (n - 1) / 2
    B = np.vstack(([N], B[:sample_length - 1]))
    similarity_ratio = A / B
    se = - np.log(similarity_ratio)
    se = np.reshape(se, -1)
    return se


def WIKISampEn(U, m, r, norm = 'cheby'):
    """This is nearly identical to  the sample entropy definition on wikipedia (accessed 10-august-2018). Can be used with either Chebychev-norm or euclidian norm. It is slow for long time series.   
    
    Args:
        U: time series 
        m: template length (will compare templates of length m with templates of length m+1
        r: tolerance
        norm: non-case sensitive string that can be either 
            'cheby', 'max', or 'Linf' for chebychev norm (AKA max-norm, infinity-norm )
            'euclid' or 'L2' for euclidian
    Returns:
        Sample Entropy
    Refences:
        [1] Wikipedia: https://en.wikipedia.org/wiki/Sample_entropy
        """
        
    if norm.lower() in ['cheby', 'linf', 'max']:
        def _maxdist(x_i, x_j):
            result = max([abs(ua - va) for ua, va in zip(x_i, x_j)])
            return result
    elif norm.lower() in ['euclid', 'l2']:
        def _maxdist(x_i, x_j):
            result = sum([(ua - va)**2 for ua, va in zip(x_i, x_j)])**(0.5)
            return result
    else:
        "This a bit sloppy way of catching errors:"
        assert False, 'norm = "' + norm + '". The norm parameter is not recoqnized'
        
    def _phi(m):
        x = [[U[j] for j in range(i, i + m - 1 + 1)] for i in range(N - m + 1)]
        C = [len([1 for j in range(len(x)) if i != j and _maxdist(x[i], x[j]) <= r]) for i in range(len(x))]
        return sum(C)

    N = len(U)

    return -np.log(_phi(m+1) / _phi(m))

if __name__ == "__main__":
    # execute only if run as a script
    
    import time
    
    "This loads the new version of the package"
    import entropy as ent 
   
    
    Nrand = 3000;
    Nint_rand = 300;
    testdat = np.random.rand(Nrand)
    testdat2 = np.array( [1, 4, 5, 1, 7, 3, 1, 2, 5, 8, 9, 7, 3, 7, 9, 5, 4, 3, 9, 1, 2, 3, 4, 2, 9, 6, 7, 4, 9, 2, 9, 9, 6,
                     5, 1, 3, 8, 1, 5, 3, 8, 4, 1, 2, 2, 1, 6, 5, 3, 6, 5, 4, 8, 9, 6, 7, 5, 3, 2, 5, 4, 2, 5, 1, 6, 5,
                     3, 5, 6, 7, 8, 5, 2, 8, 6, 3, 8, 2, 7, 1, 7, 3, 5, 6, 2, 1, 3, 7, 3, 5, 3, 7, 6, 7, 7, 2, 3, 1, 7,
                     8])
    
    tempL = 3;
    tol = 0.1;
    t0 = time.time()
    se_now = ent.sample_entropy(testdat, tempL, tol)
    t1 = time.time()
    
    se_wiki = WIKISampEn(testdat, tempL, tol, norm= 'cheby')
    t2 = time.time()
    
    se_old = sample_entropy_keep(testdat, tempL + 1, tol)
    t3 = time.time()
    
    se_now_int = ent.sample_entropy(testdat2, tempL, tol)
    
    
    se_wiki_int = WIKISampEn(testdat2, tempL, tol, norm= 'cheby')
    
    se_old_int = sample_entropy_keep(testdat2, tempL + 1, tol)
    
    
    print('\n\n---------------------------   ')
    print('Testing on random floats (N = ' + str(Nrand) + ')' )
    print('test series: ', testdat[:5], '...')
    print('New:\nSE:', se_now, '\nTime = ', round(t1-t0,3), 's\n' )
    print('WIKI (cheby):\nSE:', se_wiki, '\nTime = ', round(t2-t1,3),'s\n')
    print('Old version:\nSE:', se_old, '\nTime = ', round(t3-t2,3),'s\n')
    
    print('\n\n---------------------------   ')
    print('Testing on random integers from test-script:' )
    print('test series: ', testdat2[:5], '...')
    print('New:\nSE:', se_now_int,'\n' )
    print('WIKI (cheby):\nSE:', se_wiki_int, '\n')
    print('Old version:\nSE:', se_old_int, '\n')
    
```
 