### PR TITLE
Fixed and improved speed of permutation_entropy

### DIFF
--- a/.pytest_cache/v/cache/nodeids
+++ b/.pytest_cache/v/cache/nodeids
@@ -1,9 +1,0 @@
-[
-  "tests/test_entropy.py::TestEntropy::test_multiScaleEntropy",
-  "tests/test_entropy.py::TestEntropy::test_multiScalePermutationEntropy",
-  "tests/test_entropy.py::TestEntropy::test_permutationEntropy",
-  "tests/test_entropy.py::TestEntropy::test_sampleEntropy",
-  "tests/test_entropy.py::TestEntropy::test_shannonEntropyInt",
-  "tests/test_entropy.py::TestEntropy::test_shannonEntropyString",
-  "tests/test_entropy.py::TestEntropy::test_utilSequence"
-]

--- a/.pytest_cache/v/cache/nodeids
+++ b/.pytest_cache/v/cache/nodeids
@@ -1,0 +1,9 @@
+[
+  "tests/test_entropy.py::TestEntropy::test_multiScaleEntropy",
+  "tests/test_entropy.py::TestEntropy::test_multiScalePermutationEntropy",
+  "tests/test_entropy.py::TestEntropy::test_permutationEntropy",
+  "tests/test_entropy.py::TestEntropy::test_sampleEntropy",
+  "tests/test_entropy.py::TestEntropy::test_shannonEntropyInt",
+  "tests/test_entropy.py::TestEntropy::test_shannonEntropyString",
+  "tests/test_entropy.py::TestEntropy::test_utilSequence"
+]

--- a/pyentrp/entropy.py
+++ b/pyentrp/entropy.py
@@ -258,7 +258,8 @@ def permutation_entropy(time_series, order=3, delay=1, normalize=False):
         c[np.nonzero(hashlist == util_hash_term(sorted_idx))[0][0]] += 1
 
     c = c[np.nonzero(c)]
-    p = np.divide(c, c.sum())
+    # Use np.true_divide for Python 2 compatibility
+    p = np.true_divide(c, c.sum())
     pe = -np.multiply(p, np.log2(p)).sum()
     if normalize:
         pe /= np.log2(factorial(order))

--- a/pyentrp/entropy.py
+++ b/pyentrp/entropy.py
@@ -237,7 +237,7 @@ def permutation_entropy(time_series, m=3, delay=1, normalize=False):
 
     c = [element for element in c if element != 0]
     p = np.divide(np.array(c), float(sum(c)))
-    pe = -sum(p * np.log(p) / np.log(2))
+    pe = -sum(p * np.log2(p))
     if normalize:
         pe /= np.log2(factorial(m))
     return pe

--- a/pyentrp/entropy.py
+++ b/pyentrp/entropy.py
@@ -205,7 +205,7 @@ def permutation_entropy(time_series, order=3, delay=1, normalize=False):
 
     Parameters
     ----------
-    x : list or np.array
+    time_series : list or np.array
         Time series
     order : int
         Order of permutation entropy

--- a/pyentrp/entropy.py
+++ b/pyentrp/entropy.py
@@ -239,6 +239,13 @@ def permutation_entropy(time_series, order=3, delay=1, normalize=False):
         complexity measure for time series.
         http://stubber.math-inf.uni-greifswald.de/pub/full/prep/2001/11.pdf
 
+    Notes
+    -----
+    Last updated (Oct 2018) by Raphael Vallat (raphaelvallat9@gmail.com):
+    - Major speed improvements
+    - Use of base 2 instead of base e
+    - Added normalization
+
     Examples
     --------
     1. Permutation entropy with order 2
@@ -256,8 +263,7 @@ def permutation_entropy(time_series, order=3, delay=1, normalize=False):
             0.589
     """
     x = np.array(time_series)
-    ran_order = range(order)
-    hashmult = np.power(order, ran_order)
+    hashmult = np.power(order, np.arange(order))
     # Embed x and sort the order of permutations
     sorted_idx = _embed(x, order=order, delay=delay).argsort(kind='quicksort')
     # Associate unique integer to each permutations

--- a/pyentrp/entropy.py
+++ b/pyentrp/entropy.py
@@ -98,7 +98,6 @@ def shannon_entropy(time_series):
     for freq in freq_list:
         ent += freq * np.log2(freq)
     ent = -ent
-
     return ent
 
 
@@ -126,7 +125,7 @@ def sample_entropy(time_series, sample_length, tolerance = None):
         [2] http://physionet.incor.usp.br/physiotools/sampen/
         [3] Madalena Costa, Ary Goldberger, CK Peng. Multiscale entropy analysis
             of biological signals
-            """
+    """
     #The code below follows the sample length convention of Ref [1] so:
     M = sample_length - 1;
 
@@ -168,9 +167,7 @@ def sample_entropy(time_series, sample_length, tolerance = None):
 
 
     sampen =  - np.log(Ntemp[1:] / Ntemp[:-1])
-
     return sampen
-
 
 
 def multiscale_entropy(time_series, sample_length, tolerance = None, maxscale = None):
@@ -200,7 +197,6 @@ def multiscale_entropy(time_series, sample_length, tolerance = None, maxscale = 
     for i in range(maxscale):
         temp = util_granulate_time_series(time_series, i+1)
         mse[i] = sample_entropy(temp, sample_length, tolerance)[-1]
-
     return mse
 
 
@@ -210,13 +206,13 @@ def permutation_entropy(time_series, m=3, delay=1, normalize=False):
     Args:
         time_series : list or np.array
             Time series for analysis
-        m : order
+        m : int
             Order of permutation entropy
-        delay : delay
+        delay : int
             Time delay
         normalize : bool
             If True, divide by log2(factorial(m)) to normalize the entropy
-            between 0 and 1.
+            between 0 and 1. Otherwise, return the permutation entropy in bit.
 
     Returns:
         pe : float
@@ -295,5 +291,4 @@ def composite_multiscale_entropy(time_series, sample_length, scale, tolerance=No
         for j in range(i):
             tmp = util_granulate_time_series(time_series[j:], i + 1)
             cmse[i] += sample_entropy(tmp, sample_length, tolerance) / (i + 1)
-
     return cmse

--- a/pyentrp/entropy.py
+++ b/pyentrp/entropy.py
@@ -25,7 +25,7 @@ def _embed(x, order=3, delay=1):
         Embedded time-series.
     """
     N = len(x)
-    Y = np.zeros((order, N - (order - 1) * delay))
+    Y = np.empty((order, N - (order - 1) * delay))
     for i in range(order):
         Y[i] = x[i * delay:i * delay + Y.shape[1]]
     return Y.T

--- a/tests/test_entropy.py
+++ b/tests/test_entropy.py
@@ -16,6 +16,8 @@ TS_SAMPLE_ENTROPY = [1, 4, 5, 1, 7, 3, 1, 2, 5, 8, 9, 7, 3, 7, 9, 5, 4, 3, 9, 1,
                      3, 5, 6, 7, 8, 5, 2, 8, 6, 3, 8, 2, 7, 1, 7, 3, 5, 6, 2, 1, 3, 7, 3, 5, 3, 7, 6, 7, 7, 2, 3, 1, 7,
                      8]
 
+PERM_ENTROPY_BANDT = [4, 7, 9, 10, 6, 11, 3]
+
 np.random.seed(1234567)
 RANDOM_TIME_SERIES = np.random.rand(1000)
 
@@ -32,16 +34,19 @@ class TestEntropy(unittest.TestCase):
         sample_entropy = ent.sample_entropy(ts, 4, 0.2 * std_ts)
         np.testing.assert_array_equal(np.around(sample_entropy, 8), np.array([2.21187685, 2.12087873, 2.3826278 , 1.79175947]))
 
-    def test_multiScaleEntropy(self):  
+    def test_multiScaleEntropy(self):
         multi_scale_entropy = ent.multiscale_entropy(RANDOM_TIME_SERIES, 4, maxscale = 4 )
         np.testing.assert_array_equal(np.round(multi_scale_entropy, 8), np.array([2.52572864, 2.33537492, 1.65292302, 1.86075234]))
 
     def test_permutationEntropy(self):
-        self.assertEqual(np.round(ent.permutation_entropy(TS_SAMPLE_ENTROPY, 3, 5), 4), 1.7120)
+        self.assertEqual(np.round(ent.permutation_entropy(PERM_ENTROPY_BANDT, m=2, delay=1), 3), 0.918)
+        self.assertEqual(np.round(ent.permutation_entropy(PERM_ENTROPY_BANDT, m=3, delay=1), 3), 1.522)
+        # Assert that a fully random vector has an entropy of 0.99999...
+        self.assertEqual(np.round(ent.permutation_entropy(RANDOM_TIME_SERIES, m=3, delay=1, normalize=True), 3), 0.999)
 
     def test_multiScalePermutationEntropy(self):
         np.testing.assert_array_equal(np.round(ent.multiscale_permutation_entropy(TS_SAMPLE_ENTROPY, 3, 5, 2), 4),
-                                      np.array([1.7120, 1.7779]))
+                                      np.array([2.4699, 2.5649]))
 
     def test_utilSequence(self):
         self.assertRaises(Exception, ent.util_pattern_space, (TIME_SERIES, 0, 2))

--- a/tests/test_entropy.py
+++ b/tests/test_entropy.py
@@ -39,10 +39,10 @@ class TestEntropy(unittest.TestCase):
         np.testing.assert_array_equal(np.round(multi_scale_entropy, 8), np.array([2.52572864, 2.33537492, 1.65292302, 1.86075234]))
 
     def test_permutationEntropy(self):
-        self.assertEqual(np.round(ent.permutation_entropy(PERM_ENTROPY_BANDT, m=2, delay=1), 3), 0.918)
-        self.assertEqual(np.round(ent.permutation_entropy(PERM_ENTROPY_BANDT, m=3, delay=1), 3), 1.522)
+        self.assertEqual(np.round(ent.permutation_entropy(PERM_ENTROPY_BANDT, order=2, delay=1), 3), 0.918)
+        self.assertEqual(np.round(ent.permutation_entropy(PERM_ENTROPY_BANDT, order=3, delay=1), 3), 1.522)
         # Assert that a fully random vector has an entropy of 0.99999...
-        self.assertEqual(np.round(ent.permutation_entropy(RANDOM_TIME_SERIES, m=3, delay=1, normalize=True), 3), 0.999)
+        self.assertEqual(np.round(ent.permutation_entropy(RANDOM_TIME_SERIES, order=3, delay=1, normalize=True), 3), 0.999)
 
     def test_multiScalePermutationEntropy(self):
         np.testing.assert_array_equal(np.round(ent.multiscale_permutation_entropy(TS_SAMPLE_ENTROPY, 3, 5, 2), 4),


### PR DESCRIPTION
Hi Nikolay (@nikdon) and Jakob (@jakobdreyer),

First of all, congratulations for your great package that has proven very useful to me!

I have noticed that the permutation entropy is (1) not super fast and (2) does not return the same values as in the Bandt and Pompe 2002 paper. This PR attempts to fix both issues. I have also added an argument to normalize the permutation entropy between 0 to 1, which might be useful in some cases (e.g. machine-learning).

**1) Speed**
Using `%timeit` on arrays of different lengths, I am getting consistent speed improvements by about ~40%. This is mainly done by avoiding unnecessary conversion of lists to numpy arrays and using `np.nonzero()` instead of `np.argwhere()`. 

**2) Change of base**
I replaced this line:
`pe = -sum(p * np.log(p))`
by
`pe = -np.multiply(p, np.log2(p)).sum()`
to be consistent with the Band and Pompe 2002 paper and return a value in base 2 (=bit).

**3) Normalization**
I've added a `normalize` argument to the function. If set to True, the function returns a normalized permutation entropy (i.e. value comprised between 0 to 1):
`if normalize: pe /= np.log2(factorial(m))`

**4) Default values**
I've added `m=3` and `delay=1` as default values as I feel that those are probably the most used parameters for this function, but feel free to change that! I also renamed the argument `m` to `order`, which seems easier to understand.

**5) Testing**
I have also updated the tests. I had to update the test values for `multiscale_permutation_entropy` too since it is based on the same function. However, I did only very little change to the raw code of this latter.

**6) Code and docs**
I took the opportunity to re-write the code and documentation using the [PEP8](https://www.python.org/dev/peps/pep-0008/) and [NumpyDoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) guidelines.

Hope this will be useful!