### PR TITLE
Refactors and fixes sample entropy (last M values must be ignored)

### DIFF
--- a/pyentrp/entropy.py
+++ b/pyentrp/entropy.py
@@ -154,26 +154,11 @@ def sample_entropy(time_series, sample_length, tolerance = None):
         template = time_series[i:(i+M+1)];#We have 'M+1' elements in the template
         rem_time_series = time_series[i+1:]
 
-        searchlist = np.nonzero(np.abs(rem_time_series - template[0]) < tolerance)[0]
-
-        go = len(searchlist) > 0;
-
-        length = 1;
-
-        Ntemp[length] += len(searchlist)
-
-        while go:
-            length += 1
-            nextindxlist = searchlist + 1;
-            nextindxlist = nextindxlist[nextindxlist < n - 1 - i]#Remove candidates too close to the end
-            nextcandidates = rem_time_series[nextindxlist]
-            hitlist = np.abs(nextcandidates - template[length-1]) < tolerance
-            searchlist = nextindxlist[hitlist]
-
+        searchlist = np.arange(len(rem_time_series) - M, dtype=np.int32)
+        for length in range(1, len(template)+1):
+            hitlist = np.abs(rem_time_series[searchlist] - template[length-1]) < tolerance
             Ntemp[length] += np.sum(hitlist)
-
-            go = any(hitlist) and length < M + 1
-
+            searchlist = searchlist[hitlist] + 1
 
     sampen =  - np.log(Ntemp[1:] / Ntemp[:-1])
     return sampen

--- a/tests/test_entropy.py
+++ b/tests/test_entropy.py
@@ -32,11 +32,11 @@ class TestEntropy(unittest.TestCase):
         ts = TS_SAMPLE_ENTROPY
         std_ts = np.std(ts)
         sample_entropy = ent.sample_entropy(ts, 4, 0.2 * std_ts)
-        np.testing.assert_array_equal(np.around(sample_entropy, 8), np.array([2.21187685, 2.12087873, 2.3826278 , 1.79175947]))
+        np.testing.assert_allclose(sample_entropy, np.array([2.26881823, 2.11119024, 2.33537492, 1.79175947]))
 
     def test_multiScaleEntropy(self):
         multi_scale_entropy = ent.multiscale_entropy(RANDOM_TIME_SERIES, 4, maxscale = 4 )
-        np.testing.assert_array_equal(np.round(multi_scale_entropy, 8), np.array([2.52572864, 2.33537492, 1.65292302, 1.86075234]))
+        np.testing.assert_allclose(multi_scale_entropy, np.array([2.52572864, 2.31911439, 1.65292302, 1.86075234]))
 
     def test_permutationEntropy(self):
         self.assertEqual(np.round(ent.permutation_entropy(PERM_ENTROPY_BANDT, order=2, delay=1), 3), 0.918)


### PR DESCRIPTION
@DominiqueMakowski called my attention to a discrepancy between this implementation of the sample entropy and my implementation in [nolds](https://github.com/CSchoel/nolds) in this issue: [neuropsychology/NeuroKit#53](https://github.com/neuropsychology/NeuroKit/issues/53) .

I think there is a small issue in pyEntropy that causes this inconsistence: The sample entropy is the conditional probability that two pieces of the input sequence that are similar for M time steps will remain similar for M+1 time steps. If we count the number of similar template vector pairs of length M we therefore must ignore the last template vector, since it cannot be followed for another time step. If we would include it in the calculation, this would introduce a bias that underestimates the number of template vectors that remain similar for a length of M+1.

Reference: [Richman and Moorman (2000)](https://doi.org/10.1152/ajpheart.2000.278.6.H2039), page H2042

At Dominique's hint I found similar issues with entro-py (https://github.com/ixjlyons/entro-py/pull/2) and pyeeg (https://github.com/forrestbao/pyeeg/pull/29). With the suggested fix in this pull request, pyEntropy produces the same output as [nolds](https://github.com/CSchoel/nolds) and the R-package [pracma](https://github.com/cran/pracma/blob/master/R/entropy.R) (which I used as reference for the implementation of nolds), as well as the fixed versions of pyeeg and entro-py,

```python
import nolds
import entropy as e
import pyentrp.entropy as pent
import pyeeg.entropy as peeg
import numpy as np

num = 100
dim = 2
tol = 0.2
signal = np.cos(np.linspace(start=0, stop=30, num=num))
print("entro-py", e.sampen(signal, dim, tol, False))
print(" pyentrp", pent.sample_entropy(signal, dim + 1, tol)[-1])
print("   pyeeg", peeg.samp_entropy(signal, dim, tol))
print("   nolds", nolds.sampen(signal, emb_dim=dim, tolerance=tol))
```
```
entro-py 0.27672305866206137
 pyentrp 0.2767230586620615
   pyeeg 0.27672305866206137
   nolds 0.2767230586620615
```

Since I found the code in pyEntropy hard to understand, I took the liberty to refactor it. After I was done with that I could also identify the actual culprit in the original code. So if you would like to incorporate the fix but not my refactored version, you can alternatively pull the branch [fix_sampen](https://github.com/CSchoel/pyEntropy/tree/fix_sampen) in my fork.