### PR TITLE
fix: use 1d vector for cmse output

### DIFF
--- a/pyentrp/entropy.py
+++ b/pyentrp/entropy.py
@@ -373,7 +373,7 @@ def composite_multiscale_entropy(time_series, sample_length, scale, tolerance=No
         [1] Wu, Shuen-De, et al. "Time series analysis using
             composite multiscale entropy." Entropy 15.3 (2013): 1069-1084.
     """
-    cmse = np.zeros((1, scale))
+    cmse = np.zeros(scale)
 
     for i in range(scale):
         for j in range(i):


### PR DESCRIPTION
This fixes a bug that occurs when indexing `csme` when scale > 1 (e.g., 2) 

Bug occurs here :arrow_down:

https://github.com/nikdon/pyEntropy/blob/9320bcc00989e0b35e89a4b45e8f1ee0487203b6/pyentrp/entropy.py#L381

Cause of bug is `cmse` being flat in the 1st dimension :arrow_down: 

https://github.com/nikdon/pyEntropy/blob/9320bcc00989e0b35e89a4b45e8f1ee0487203b6/pyentrp/entropy.py#L376


Solution => just remove first dimension and use `np.zeros(scale)`